### PR TITLE
fix(tui): decline concurrent incoming transfers (Codex P2 review on #6)

### DIFF
--- a/src/tui/store.test.ts
+++ b/src/tui/store.test.ts
@@ -273,6 +273,54 @@ test("quickSave 'on' auto-accepts without a modal", async () => {
 	expect(store.state.incomingRequest).toBeNull()
 })
 
+test("a second incoming request is declined while the first consent is pending", async () => {
+	const { deps, fireRequest } = makeDeps()
+	const store = createTuiStore(info, deps)
+	await store.boot()
+	const first = fireRequest(makeDevice("10.0.0.9", { alias: "First" }), {
+		a: fileMeta("a", "photo.png", 100)
+	})
+	expect(store.state.incomingRequest?.sender.alias).toBe("First")
+
+	// A second sender arrives before the first is answered: it must be declined
+	// outright, and the first request's pending promise must be preserved.
+	const second = await fireRequest(makeDevice("10.0.0.8", { alias: "Second" }), {
+		b: fileMeta("b", "doc.pdf", 200)
+	})
+	expect(second).toBe(false)
+	expect(store.state.incomingRequest?.sender.alias).toBe("First")
+
+	store.acceptIncoming()
+	await expect(first!).resolves.toBe(true)
+})
+
+test("an incoming request is declined while an outbound send is in flight", async () => {
+	const { deps, fireRequest } = makeDeps()
+	let release: () => void = () => {}
+	deps.sendPath = async () => {
+		await new Promise<void>((r) => {
+			release = r
+		})
+		return { ok: true, message: "sent" }
+	}
+	const store = createTuiStore(info, deps)
+	await store.boot()
+	store.addDevice(makeDevice("10.0.0.5", { alias: "Peer" }))
+	await store.addPath(import.meta.path)
+	const sending = store.sendToDevice(store.selectedDevice()!)
+	expect(store.state.session?.status).toBe("sending")
+
+	// A receiver request that lands mid-send must not clobber the send session.
+	const accepted = await fireRequest(makeDevice("10.0.0.9", { alias: "Sender" }), {
+		a: fileMeta("a", "photo.png", 100)
+	})
+	expect(accepted).toBe(false)
+	expect(store.state.session?.direction).toBe("send")
+
+	release()
+	await sending
+})
+
 test("favorites toggle persists and sorts favorites first", async () => {
 	const mem = memoryPersist()
 	const { deps } = makeDeps({ persist: mem.persist })

--- a/src/tui/store.test.ts
+++ b/src/tui/store.test.ts
@@ -53,6 +53,16 @@ function makeDeps(persistOverride?: { persist: Persist }) {
 	let requestHandler:
 		| ((info: DeviceInfo, files: Record<string, FileMetadata>) => Promise<boolean>)
 		| null = null
+	let progressHandler:
+		| ((
+				fileId: string,
+				fileName: string,
+				received: number,
+				total: number,
+				speed: number,
+				finished: boolean
+		  ) => void | Promise<void>)
+		| null = null
 	const deps: TuiDeps = {
 		createDiscovery: () => ({
 			onDeviceDiscovered: (cb) => {
@@ -66,6 +76,7 @@ function makeDeps(persistOverride?: { persist: Persist }) {
 		createServer: (_info, options) => {
 			serverOptions = options as Record<string, unknown> | undefined
 			requestHandler = options?.onTransferRequest ?? null
+			progressHandler = options?.onTransferProgress ?? null
 			return {
 				start: async () => {
 					calls.serverStart++
@@ -92,6 +103,14 @@ function makeDeps(persistOverride?: { persist: Persist }) {
 		clock,
 		emitDevice: (d: DeviceInfo) => discoveredCb?.(d),
 		fireRequest: (i: DeviceInfo, files: Record<string, FileMetadata>) => requestHandler?.(i, files),
+		fireProgress: (
+			fileId: string,
+			fileName: string,
+			received: number,
+			total: number,
+			speed: number,
+			finished: boolean
+		) => progressHandler?.(fileId, fileName, received, total, speed, finished),
 		serverOptions: () => serverOptions
 	}
 }
@@ -349,6 +368,37 @@ test("a stalled receive can be canceled so it stops blocking new transfers", asy
 		c: fileMeta("c", "z.bin", 100)
 	})
 	expect(accepted).toBe(true)
+})
+
+test("progress from a canceled receive does not leak into the next session", async () => {
+	const { deps, fireRequest, fireProgress } = makeDeps()
+	const store = createTuiStore(info, deps)
+	await store.boot()
+	store.cycleQuickSave() // off -> favorites
+	store.cycleQuickSave() // favorites -> on
+
+	// Receive A starts, then the user cancels it while its upload is still live.
+	await fireRequest(makeDevice("10.0.0.9", { alias: "A" }), { a: fileMeta("a", "x.bin", 100) })
+	store.cancelSession()
+	expect(store.state.session?.status).toBe("canceledByReceiver")
+
+	// A's upload keeps streaming and even reports finished — a settled session
+	// must not be revived, and nothing should be recorded.
+	await fireProgress("a", "x.bin", 100, 100, 0, true)
+	expect(store.state.session?.status).toBe("canceledByReceiver")
+	expect(store.state.recentReceives.length).toBe(0)
+
+	// A new receive B is accepted; A's stale progress must not touch B.
+	await fireRequest(makeDevice("10.0.0.8", { alias: "B" }), { b: fileMeta("b", "y.bin", 200) })
+	expect(store.state.session?.status).toBe("sending")
+	await fireProgress("a", "x.bin", 100, 100, 0, true)
+	expect(store.state.recentReceives.length).toBe(0)
+	expect(store.state.session?.files[0]?.status).toBe("sending")
+
+	// Legit progress for B still completes it.
+	await fireProgress("b", "y.bin", 200, 200, 0, true)
+	expect(store.state.session?.status).toBe("finished")
+	expect(store.state.recentReceives[0]?.fileName).toBe("y.bin")
 })
 
 test("favorites toggle persists and sorts favorites first", async () => {

--- a/src/tui/store.test.ts
+++ b/src/tui/store.test.ts
@@ -321,6 +321,36 @@ test("an incoming request is declined while an outbound send is in flight", asyn
 	await sending
 })
 
+test("a stalled receive can be canceled so it stops blocking new transfers", async () => {
+	const { deps, fireRequest } = makeDeps()
+	const store = createTuiStore(info, deps)
+	await store.boot()
+	store.cycleQuickSave() // off -> favorites
+	store.cycleQuickSave() // favorites -> on (auto-accept)
+
+	// First receive auto-accepts and sits in "sending" — a real upload that
+	// errored/disconnected never fires a finished progress event.
+	await fireRequest(makeDevice("10.0.0.9", { alias: "A" }), { a: fileMeta("a", "x.bin", 100) })
+	expect(store.state.session?.direction).toBe("receive")
+	expect(store.state.session?.status).toBe("sending")
+
+	// While it is stuck, a new incoming is declined as busy.
+	const blocked = await fireRequest(makeDevice("10.0.0.8", { alias: "B" }), {
+		b: fileMeta("b", "y.bin", 100)
+	})
+	expect(blocked).toBe(false)
+
+	// The user cancels the stalled receive, settling it.
+	store.cancelSession()
+	expect(store.state.session?.status).toBe("canceledByReceiver")
+
+	// A new incoming is now accepted again instead of being permanently rejected.
+	const accepted = await fireRequest(makeDevice("10.0.0.7", { alias: "C" }), {
+		c: fileMeta("c", "z.bin", 100)
+	})
+	expect(accepted).toBe(true)
+})
+
 test("favorites toggle persists and sorts favorites first", async () => {
 	const mem = memoryPersist()
 	const { deps } = makeDeps({ persist: mem.persist })

--- a/src/tui/store.ts
+++ b/src/tui/store.ts
@@ -682,8 +682,20 @@ export function createTuiStore(
 	}
 
 	const cancelSession = () => {
-		if (state.session?.direction === "send" && state.session.status === "sending") {
+		if (!state.session) return
+		if (state.session.direction === "send" && state.session.status === "sending") {
 			cancelRequested = true
+		} else if (
+			state.session.direction === "receive" &&
+			(state.session.status === "sending" || state.session.status === "waiting")
+		) {
+			// A receive has no sender-side abort and no error callback, so an
+			// upload that errors or disconnects mid-flight would otherwise pin the
+			// session in "sending" forever — and the busy-guard in `handleIncoming`
+			// would then reject every future transfer until restart. Let the user
+			// settle a stuck receive so its overlay is dismissible and the receiver
+			// is no longer treated as busy.
+			setState("session", { status: "canceledByReceiver", doneAt: deps.now() })
 		}
 	}
 

--- a/src/tui/store.ts
+++ b/src/tui/store.ts
@@ -578,13 +578,20 @@ export function createTuiStore(
 		finished: boolean
 	) => {
 		if (!state.session || state.session.direction !== "receive") return
+		// Ignore progress once the receive is settled: if the user canceled a
+		// stuck receive (marking it canceledByReceiver), an upload that keeps
+		// streaming must not revive that overlay — and must not leak into a
+		// later session accepted after the cancel.
+		if (state.session.status !== "sending" && state.session.status !== "waiting") return
 		const idx = state.session.files.findIndex((f) => f.id === fileId)
-		if (idx >= 0) {
-			setState("session", "files", idx, {
-				received,
-				status: finished ? "done" : "sending"
-			})
-		}
+		// Progress for a file that isn't part of the current session (a stale
+		// event from a prior/canceled upload) must not touch this session's
+		// speed, recent-receives, or completion accounting.
+		if (idx < 0) return
+		setState("session", "files", idx, {
+			received,
+			status: finished ? "done" : "sending"
+		})
 		setState("session", "speed", speed)
 		if (finished) {
 			setState("recentReceives", (list) => [

--- a/src/tui/store.ts
+++ b/src/tui/store.ts
@@ -487,6 +487,18 @@ export function createTuiStore(
 		senderInfo: DeviceInfo,
 		files: Record<string, FileMetadata>
 	): Promise<boolean> => {
+		// Single-session model: decline a new request while another transfer is
+		// in flight or a consent prompt is still pending. Accepting would replace
+		// the live `session` (a running send queue would then mutate what is now a
+		// receive session) or overwrite `incomingRequest` and drop the first
+		// sender's unresolved consent promise, leaving it to hang until timeout.
+		// The sender gets a clean decline instead.
+		const busy =
+			state.incomingRequest != null ||
+			(state.session != null &&
+				(state.session.status === "sending" || state.session.status === "waiting"))
+		if (busy) return Promise.resolve(false)
+
 		const fingerprint = senderInfo.fingerprint
 		const senderIsFavorite = isFavorite(fingerprint)
 		if (state.quickSave === "on" || (state.quickSave === "favorites" && senderIsFavorite)) {


### PR DESCRIPTION
Follow-up to the Codex review on #6. I triaged all 5 P2 comments:

| # | Comment | Status |
|---|---------|--------|
| 1 | Don't dismiss active transfers with Escape (`App.tsx`) | **Already fixed** on `main` — `App.tsx` Escape only closes a *settled* session; mid-transfer it cancels instead. |
| 2 | Make cancel affect the in-flight file (`store.ts`) | **Already fixed** on `main` — `runSendQueue` re-checks `cancelRequested` after the upload `await` before marking the file done. |
| 3 | Treat bare launch as a TUI request (`cli.ts`) | **Already fixed** on `main` — the FFI-less branch leads with the TUI/Bun guidance for bare `localsend` too (only `--tui` exits non-zero). |
| 4 | Reject incoming transfers while busy (`store.ts`) | **Fixed here.** |
| 5 | Preserve the first pending consent request (`store.ts`) | **Fixed here.** |

### The fix (4 & 5)
`handleIncoming` set `incomingRequest`/`session` unconditionally. Under the single-session model that let a second request overwrite the first sender's unresolved `resolve` closure (its HTTP request hung until timeout), and let an incoming transfer accepted during an outbound send replace the send `session` while `runSendQueue` was still mutating it (overlay corruption / throw on file-count mismatch).

Now `handleIncoming` declines (`resolve(false)`) whenever a transfer is already in flight (`session` sending/waiting) or a consent prompt is pending (`incomingRequest` set). The sender gets a clean decline instead of a hang or corruption.

### Tests / gate
- Two new store tests: a second incoming during a pending consent is declined and the first promise is preserved; an incoming during an in-flight send is declined and the send session is untouched.
- `bun test src/` — 44 pass / 0 fail; `tsc --noEmit` clean; prettier clean.